### PR TITLE
[SRLT-143] Feat: 여러 항목에 대해 진행중을 표현한다

### DIFF
--- a/src/main/java/starlight/adapter/backoffice/expert/webapi/dto/request/BackofficeExpertUpdateRequest.java
+++ b/src/main/java/starlight/adapter/backoffice/expert/webapi/dto/request/BackofficeExpertUpdateRequest.java
@@ -1,7 +1,6 @@
 package starlight.adapter.backoffice.expert.webapi.dto.request;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -9,7 +8,6 @@ import starlight.application.backoffice.expert.provided.dto.input.BackofficeExpe
 import starlight.application.backoffice.expert.provided.dto.input.BackofficeExpertUpdateInput;
 import starlight.domain.expert.enumerate.TagCategory;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 
@@ -51,38 +49,5 @@ public record BackofficeExpertUpdateRequest(
                 categories,
                 careerInputs
         );
-    }
-
-    @AssertTrue(message = "종료일이 없는 경력은 최신 경력 1건만 허용됩니다.")
-    public boolean isValidCurrentCareer() {
-        if (careers == null || careers.isEmpty()) {
-            return true;
-        }
-
-        List<BackofficeExpertCareerUpdateRequest> careersWithoutEndDate = careers.stream()
-                .filter(Objects::nonNull)
-                .filter(career -> career.careerEndedAt() == null)
-                .toList();
-
-        if (careersWithoutEndDate.isEmpty()) {
-            return true;
-        }
-
-        if (careersWithoutEndDate.size() > 1) {
-            return false;
-        }
-
-        Integer maxOrderIndex = careers.stream()
-                .filter(Objects::nonNull)
-                .map(BackofficeExpertCareerUpdateRequest::orderIndex)
-                .filter(Objects::nonNull)
-                .max(Comparator.naturalOrder())
-                .orElse(null);
-
-        if (maxOrderIndex == null) {
-            return true;
-        }
-
-        return Objects.equals(careersWithoutEndDate.get(0).orderIndex(), maxOrderIndex);
     }
 }

--- a/src/main/java/starlight/domain/expert/entity/Expert.java
+++ b/src/main/java/starlight/domain/expert/entity/Expert.java
@@ -203,19 +203,6 @@ public class Expert extends AbstractEntity {
 
         boolean hasDuplicateOrderIndex = orderIndexes.size() != careerUpdates.size();
         boolean hasDuplicateIds = requestedIds.size() != requestedIdCount;
-        long currentCareerCount = careerUpdates.stream()
-                .filter(update -> update.careerEndedAt() == null)
-                .count();
-        Integer maxOrderIndex = careerUpdates.stream()
-                .map(ExpertCareerUpdate::orderIndex)
-                .filter(Objects::nonNull)
-                .max(Integer::compareTo)
-                .orElse(null);
-        boolean hasInvalidCurrentCareer = currentCareerCount > 1
-                || careerUpdates.stream().anyMatch(update ->
-                update.careerEndedAt() == null
-                        && !Objects.equals(update.orderIndex(), maxOrderIndex)
-        );
         boolean hasInvalidPeriod = careerUpdates.stream().anyMatch(update ->
                 update.orderIndex() == null
                         || update.orderIndex() < 0
@@ -224,7 +211,7 @@ public class Expert extends AbstractEntity {
                         && update.careerStartedAt().isAfter(update.careerEndedAt()))
         );
 
-        if (hasDuplicateOrderIndex || hasDuplicateIds || hasInvalidPeriod || hasInvalidCurrentCareer) {
+        if (hasDuplicateOrderIndex || hasDuplicateIds || hasInvalidPeriod) {
             throw new ExpertException(ExpertErrorType.EXPERT_CAREER_INVALID);
         }
     }


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- 기존 백엔드에서는 종료일이 없는 경력을 최신 1건만 허용하고 있었습니다.
- 하지만 실제 운영 요구사항상 한 전문가가 여러 경력을 동시에 진행 중일 수 있어, 이 제한이 실제 데이터를 충분히 담지 못하는 문제가 있었습니다.

## ✅ What - 무엇이 변경됐나요?

- 종료일이 없는 경력을 1건만 허용하던 제한을 제거했습니다.
- 여러 경력을 동시에 `진행 중` 상태로 저장할 수 있도록 백엔드 검증 로직을 수정했습니다.
- 종료일이 없는 경력도 안전하게 처리되도록 request 변환과 validation 방어 로직을 보완했습니다.

## 🛠️ How - 어떻게 해결했나요?

- `BackofficeExpertUpdateRequest`에서 `종료일이 없는 경력은 최신 경력 1건만 허용`하던 검증 로직을 제거했습니다.
- `Expert.validateCareerUpdates()`에서 종료일이 `null`인 경력의 개수나 최신 여부를 검사하던 로직을 제거했습니다.
- 대신 기존의 기본 검증은 유지했습니다.
  - `orderIndex` 중복 여부
  - 경력 ID 중복 여부
  - `orderIndex` 음수 여부
  - 시작일 존재 여부
  - 종료일이 있을 경우에만 시작일/종료일 대소 비교
- `careers` 리스트 내 null 요소로 인한 NPE를 막기 위해 요소 단위 null validation 및 `Objects::nonNull` 필터를 유지했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **버그 수정**
  * 전문가 경력 정보 검증 로직을 단순화했습니다. 이제 기본 검증(중복된 순서 인덱스, ID 중복, 유효하지 않은 기간)만 수행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->