### PR TITLE
[SRLT-126] PDF로 채점 등, 전문으로 채점시에 RAG 제외

### DIFF
--- a/src/main/java/starlight/adapter/aireport/report/agent/impl/SpringAiFullReportGradeAgent.java
+++ b/src/main/java/starlight/adapter/aireport/report/agent/impl/SpringAiFullReportGradeAgent.java
@@ -36,8 +36,6 @@ public class SpringAiFullReportGradeAgent implements FullReportGradeAgent {
                         Prompt prompt = reportPromptProvider.createReportGradingPrompt(content);
 
                         ChatClient chatClient = chatClientBuilder.build();
-                        QuestionAnswerAdvisor qaAdvisor = advisorProvider
-                                        .getQuestionAnswerAdvisor(0.6, 3, null);
                         SimpleLoggerAdvisor slAdvisor = advisorProvider.getSimpleLoggerAdvisor();
 
                         String llmResponse = chatClient
@@ -46,7 +44,7 @@ public class SpringAiFullReportGradeAgent implements FullReportGradeAgent {
                                                         .temperature(0.0)
                                                         .topP(0.1)
                                                         .build())
-                                        .advisors(qaAdvisor, slAdvisor)
+                                        .advisors(slAdvisor)
                                         .call()
                                         .content();
 


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- `어떤 문제를 해결하고자 하나요?`
  - PDF 채점시에 전문을 RAG에 사용하다 보니 벡터 임베딩 토큰(8192 tokens)에서 초과되어 500 에러가 발생했었음 

## ✅ What - 무엇이 변경됐나요?

- `주요 변경사항`
  - 전문으로 채점시에 RAG 제외시킴 (컨텍스트 윈도우 초과 방지)

## 🛠️ How - 어떻게 해결했나요?

- `핵심 로직 설명`
  -   - 전문으로 채점하는 SpringAiFullReportGradeAgent 구현체에서 chatClient에 QuestionAnswerAdvisor를 제외시켜 RAG 제외시킴

## 🖼️ Attachment

- `화면 이미지, 결과 캡처 등 첨부`

## 💬 기타 코멘트

- `리뷰어에게 전하고 싶은 말, 테스트 방법, 주의할 점 등`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **리팩토링**
  * AI 보고서 등급 처리 시스템의 내부 어드바이저 구성을 단순화하여 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->