### PR TITLE
[SRLT-156] Oracle manifest 워크플로우로 정리

### DIFF
--- a/.github/workflows/ci-prd.yaml
+++ b/.github/workflows/ci-prd.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Checkout manifest repository
         uses: actions/checkout@v6
         with:
-          repository: 'StartUpLight/STARLIGHT_MANIFEST'
+          repository: 'StartUpLight/STARLIGHT_MANIFEST_ORACLE'
           token: ${{ secrets.PAT }}
           path: 'manifest'
 

--- a/.github/workflows/ci-stg.yaml
+++ b/.github/workflows/ci-stg.yaml
@@ -64,16 +64,9 @@ jobs:
       - name: Checkout manifest repository
         uses: actions/checkout@v6
         with:
-          repository: 'StartUpLight/STARLIGHT_MANIFEST'
-          token: ${{ secrets.PAT }}
-          path: 'manifest'
-
-      - name: Checkout manifest repository (oracle)
-        uses: actions/checkout@v6
-        with:
           repository: 'StartUpLight/STARLIGHT_MANIFEST_ORACLE'
           token: ${{ secrets.PAT }}
-          path: 'manifest-oracle'
+          path: 'manifest'
 
       - name: Update deployment.yml and push manifests
         env:
@@ -117,4 +110,3 @@ jobs:
           }
 
           update_manifest manifest
-          update_manifest manifest-oracle


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- 현재 배포 대상 manifest repo는 `STARLIGHT_MANIFEST_ORACLE`만 사용하면 됩니다.
- BE 배포 워크플로우가 더 이상 기존 `STARLIGHT_MANIFEST`를 수정하지 않도록 정리했습니다.

## ✅ What - 무엇이 변경됐나요?

- staging 배포 워크플로우에서 `STARLIGHT_MANIFEST` 업데이트를 제거했습니다.
- staging/production 모두 `STARLIGHT_MANIFEST_ORACLE`만 checkout하고 image tag를 업데이트하도록 변경했습니다.

## 🛠️ How - 어떻게 해결했나요?

- `ci-stg.yaml`, `ci-prd.yaml`의 manifest checkout 대상을 `StartUpLight/STARLIGHT_MANIFEST_ORACLE`로 통일했습니다.
- `STARLIGHT_MANIFEST` 자체 정리는 별도 작업에서 진행할 예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CI/CD 배포 워크플로우가 업데이트되었습니다. 프로덕션 및 스테이징 환경의 배포 프로세스에서 사용하는 매니페스트 저장소가 변경되었으며, 배포 자동화 파이프라인이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->