### PR TITLE
[SRLT-157] SSE 재연결 알림 복구 추가

### DIFF
--- a/src/main/java/starlight/adapter/notification/persistence/NotificationJpa.java
+++ b/src/main/java/starlight/adapter/notification/persistence/NotificationJpa.java
@@ -31,4 +31,9 @@ public class NotificationJpa implements NotificationCommandPort, NotificationQue
     public List<Notification> findAllByMemberIdOrderByIdDesc(Long memberId) {
         return notificationRepository.findAllByMemberIdOrderByIdDesc(memberId);
     }
+
+    @Override
+    public List<Notification> findAllByMemberIdAndIdGreaterThanOrderByIdAsc(Long memberId, Long notificationId) {
+        return notificationRepository.findAllByMemberIdAndIdGreaterThanOrderByIdAsc(memberId, notificationId);
+    }
 }

--- a/src/main/java/starlight/adapter/notification/persistence/NotificationRepository.java
+++ b/src/main/java/starlight/adapter/notification/persistence/NotificationRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     List<Notification> findAllByMemberIdOrderByIdDesc(Long memberId);
+
+    List<Notification> findAllByMemberIdAndIdGreaterThanOrderByIdAsc(Long memberId, Long notificationId);
 }

--- a/src/main/java/starlight/adapter/notification/sse/NotificationSseRegistry.java
+++ b/src/main/java/starlight/adapter/notification/sse/NotificationSseRegistry.java
@@ -25,7 +25,7 @@ public class NotificationSseRegistry implements NotificationRealtimePort {
     private final Map<Long, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
 
     @Override
-    public SseEmitter subscribe(Long memberId) {
+    public SseEmitter subscribe(Long memberId, List<NotificationPublishMessage> missedMessages) {
         SseEmitter emitter = new SseEmitter(sseTimeoutMs);
         addEmitter(memberId, emitter);
 
@@ -40,6 +40,7 @@ public class NotificationSseRegistry implements NotificationRealtimePort {
                             .name("connected")
                             .data("ok", MediaType.TEXT_PLAIN)
             );
+            sendMissedMessages(emitter, memberId, missedMessages);
         } catch (IOException | IllegalStateException exception) {
             removeEmitter(memberId, emitter);
             emitter.completeWithError(exception);
@@ -59,10 +60,7 @@ public class NotificationSseRegistry implements NotificationRealtimePort {
             try {
                 safeSend(
                         emitter,
-                        SseEmitter.event()
-                                .id(String.valueOf(message.notificationId()))
-                                .name("notification")
-                                .data(message, MediaType.APPLICATION_JSON)
+                        createNotificationEvent(message)
                 );
             } catch (IOException | IllegalStateException exception) {
                 log.warn("[NOTIFICATION] SSE send failed notificationId={}, memberId={}",
@@ -97,6 +95,27 @@ public class NotificationSseRegistry implements NotificationRealtimePort {
                 }
             }
         }
+    }
+
+    private void sendMissedMessages(
+            SseEmitter emitter,
+            Long memberId,
+            List<NotificationPublishMessage> missedMessages
+    ) throws IOException {
+        for (NotificationPublishMessage missedMessage : missedMessages) {
+            if (!memberId.equals(missedMessage.memberId())) {
+                continue;
+            }
+
+            safeSend(emitter, createNotificationEvent(missedMessage));
+        }
+    }
+
+    private SseEmitter.SseEventBuilder createNotificationEvent(NotificationPublishMessage message) {
+        return SseEmitter.event()
+                .id(String.valueOf(message.notificationId()))
+                .name("notification")
+                .data(message, MediaType.APPLICATION_JSON);
     }
 
     private void addEmitter(Long memberId, SseEmitter emitter) {

--- a/src/main/java/starlight/adapter/notification/webapi/NotificationController.java
+++ b/src/main/java/starlight/adapter/notification/webapi/NotificationController.java
@@ -7,8 +7,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import starlight.adapter.notification.webapi.dto.request.NotificationTestRequest;
@@ -32,13 +34,16 @@ public class NotificationController implements NotificationApiDoc {
     @Override
     @GetMapping("/subscribe")
     public SseEmitter subscribe(
-            @AuthenticationPrincipal AuthenticatedMember authenticatedMember
+            @AuthenticationPrincipal AuthenticatedMember authenticatedMember,
+            @RequestHeader(value = "Last-Event-ID", required = false) Long lastEventIdHeader,
+            @RequestParam(value = "lastEventId", required = false) Long lastEventId
     ) {
         if (authenticatedMember == null) {
             throw new GlobalException(GlobalErrorType.UNAUTHORIZED);
         }
 
-        return notificationUseCase.subscribe(authenticatedMember.getMemberId());
+        Long resolvedLastEventId = lastEventId != null ? lastEventId : lastEventIdHeader;
+        return notificationUseCase.subscribe(authenticatedMember.getMemberId(), resolvedLastEventId);
     }
 
     @Override

--- a/src/main/java/starlight/adapter/notification/webapi/NotificationController.java
+++ b/src/main/java/starlight/adapter/notification/webapi/NotificationController.java
@@ -42,7 +42,7 @@ public class NotificationController implements NotificationApiDoc {
             throw new GlobalException(GlobalErrorType.UNAUTHORIZED);
         }
 
-        Long resolvedLastEventId = lastEventId != null ? lastEventId : lastEventIdHeader;
+        Long resolvedLastEventId = lastEventIdHeader != null ? lastEventIdHeader : lastEventId;
         return notificationUseCase.subscribe(authenticatedMember.getMemberId(), resolvedLastEventId);
     }
 

--- a/src/main/java/starlight/adapter/notification/webapi/swagger/NotificationApiDoc.java
+++ b/src/main/java/starlight/adapter/notification/webapi/swagger/NotificationApiDoc.java
@@ -1,6 +1,7 @@
 package starlight.adapter.notification.webapi.swagger;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -13,7 +14,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import starlight.adapter.notification.webapi.dto.request.NotificationTestRequest;
 import starlight.adapter.notification.webapi.dto.response.NotificationResponse;
@@ -29,7 +32,11 @@ public interface NotificationApiDoc {
     @Operation(summary = "알림 SSE를 구독합니다.")
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     SseEmitter subscribe(
-            @AuthenticationPrincipal AuthenticatedMember authenticatedMember
+            @AuthenticationPrincipal AuthenticatedMember authenticatedMember,
+            @Parameter(description = "SSE 재연결 시 브라우저가 전달하는 마지막 수신 이벤트 ID")
+            @RequestHeader(value = "Last-Event-ID", required = false) Long lastEventIdHeader,
+            @Parameter(description = "Last-Event-ID 헤더를 사용하기 어려운 클라이언트용 마지막 수신 이벤트 ID")
+            @RequestParam(value = "lastEventId", required = false) Long lastEventId
     );
 
     @Operation(summary = "내 알림 목록을 조회합니다.")

--- a/src/main/java/starlight/application/notification/NotificationService.java
+++ b/src/main/java/starlight/application/notification/NotificationService.java
@@ -13,6 +13,7 @@ import starlight.application.notification.required.NotificationCommandPort;
 import starlight.application.notification.required.NotificationOutboxCommandPort;
 import starlight.application.notification.required.NotificationQueryPort;
 import starlight.application.notification.required.NotificationRealtimePort;
+import starlight.application.notification.required.dto.NotificationPublishMessage;
 import starlight.domain.notification.entity.Notification;
 import starlight.domain.notification.entity.NotificationOutbox;
 
@@ -66,7 +67,19 @@ public class NotificationService implements NotificationUseCase {
     }
 
     @Override
-    public SseEmitter subscribe(Long memberId) {
-        return notificationRealtimePort.subscribe(memberId);
+    @Transactional(readOnly = true)
+    public SseEmitter subscribe(Long memberId, Long lastEventId) {
+        List<NotificationPublishMessage> missedMessages = findMissedMessages(memberId, lastEventId);
+        return notificationRealtimePort.subscribe(memberId, missedMessages);
+    }
+
+    private List<NotificationPublishMessage> findMissedMessages(Long memberId, Long lastEventId) {
+        if (lastEventId == null) {
+            return List.of();
+        }
+
+        return notificationQueryPort.findAllByMemberIdAndIdGreaterThanOrderByIdAsc(memberId, lastEventId).stream()
+                .map(NotificationPublishMessage::from)
+                .toList();
     }
 }

--- a/src/main/java/starlight/application/notification/NotificationService.java
+++ b/src/main/java/starlight/application/notification/NotificationService.java
@@ -74,7 +74,7 @@ public class NotificationService implements NotificationUseCase {
     }
 
     private List<NotificationPublishMessage> findMissedMessages(Long memberId, Long lastEventId) {
-        if (lastEventId == null) {
+        if (lastEventId == null || lastEventId <= 0) {
             return List.of();
         }
 

--- a/src/main/java/starlight/application/notification/provided/NotificationUseCase.java
+++ b/src/main/java/starlight/application/notification/provided/NotificationUseCase.java
@@ -14,5 +14,5 @@ public interface NotificationUseCase {
 
     void markAsRead(Long notificationId, Long memberId);
 
-    SseEmitter subscribe(Long memberId);
+    SseEmitter subscribe(Long memberId, Long lastEventId);
 }

--- a/src/main/java/starlight/application/notification/required/NotificationQueryPort.java
+++ b/src/main/java/starlight/application/notification/required/NotificationQueryPort.java
@@ -9,4 +9,6 @@ public interface NotificationQueryPort {
     Notification findByIdOrThrow(Long notificationId);
 
     List<Notification> findAllByMemberIdOrderByIdDesc(Long memberId);
+
+    List<Notification> findAllByMemberIdAndIdGreaterThanOrderByIdAsc(Long memberId, Long notificationId);
 }

--- a/src/main/java/starlight/application/notification/required/NotificationRealtimePort.java
+++ b/src/main/java/starlight/application/notification/required/NotificationRealtimePort.java
@@ -3,9 +3,11 @@ package starlight.application.notification.required;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import starlight.application.notification.required.dto.NotificationPublishMessage;
 
+import java.util.List;
+
 public interface NotificationRealtimePort {
 
-    SseEmitter subscribe(Long memberId);
+    SseEmitter subscribe(Long memberId, List<NotificationPublishMessage> missedMessages);
 
     void send(NotificationPublishMessage message);
 }

--- a/src/test/java/starlight/application/notification/NotificationServiceUnitTest.java
+++ b/src/test/java/starlight/application/notification/NotificationServiceUnitTest.java
@@ -131,4 +131,16 @@ class NotificationServiceUnitTest {
                 messages.size() == 1 && messages.getFirst().notificationId().equals(11L)
         ));
     }
+
+    @Test
+    void subscribe_lastEventId가_0이하면_누락알림을_조회하지_않는다() {
+        SseEmitter emitter = new SseEmitter();
+
+        when(notificationRealtimePort.subscribe(1L, List.of())).thenReturn(emitter);
+
+        SseEmitter result = notificationService.subscribe(1L, 0L);
+
+        assertSame(emitter, result);
+        verify(notificationQueryPort, never()).findAllByMemberIdAndIdGreaterThanOrderByIdAsc(anyLong(), anyLong());
+    }
 }

--- a/src/test/java/starlight/application/notification/NotificationServiceUnitTest.java
+++ b/src/test/java/starlight/application/notification/NotificationServiceUnitTest.java
@@ -106,10 +106,29 @@ class NotificationServiceUnitTest {
     void subscribe_실시간포트에_위임한다() {
         SseEmitter emitter = new SseEmitter();
 
-        when(notificationRealtimePort.subscribe(1L)).thenReturn(emitter);
+        when(notificationRealtimePort.subscribe(1L, List.of())).thenReturn(emitter);
 
-        SseEmitter result = notificationService.subscribe(1L);
+        SseEmitter result = notificationService.subscribe(1L, null);
 
         assertSame(emitter, result);
+    }
+
+    @Test
+    void subscribe_lastEventId가_있으면_누락알림을_조회해_전달한다() {
+        SseEmitter emitter = new SseEmitter();
+        Notification notification = Notification.create(1L, "SYSTEM", "title", "message", null);
+        ReflectionTestUtils.setField(notification, "id", 11L);
+
+        when(notificationQueryPort.findAllByMemberIdAndIdGreaterThanOrderByIdAsc(1L, 10L))
+                .thenReturn(List.of(notification));
+        when(notificationRealtimePort.subscribe(eq(1L), anyList())).thenReturn(emitter);
+
+        SseEmitter result = notificationService.subscribe(1L, 10L);
+
+        assertSame(emitter, result);
+        verify(notificationQueryPort).findAllByMemberIdAndIdGreaterThanOrderByIdAsc(1L, 10L);
+        verify(notificationRealtimePort).subscribe(eq(1L), argThat(messages ->
+                messages.size() == 1 && messages.getFirst().notificationId().equals(11L)
+        ));
     }
 }


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- SSE 연결이 끊긴 동안 Redis Pub/Sub으로 전달된 알림은 클라이언트가 실시간으로 받지 못할 수 있습니다.
- 알림 데이터는 DB에 저장되어 있지만, 기존 `/subscribe` 흐름에서는 재연결 시 마지막 수신 이벤트 이후의 누락 알림을 자동으로 복구해주지 않았습니다.

## ✅ What - 무엇이 변경됐나요?

- SSE 구독 API에서 `Last-Event-ID` 헤더와 `lastEventId` 쿼리 파라미터를 받을 수 있도록 변경했습니다.
- `memberId + lastEventId` 기준으로 이후 알림을 DB에서 조회하는 포트/레포지토리 메서드를 추가했습니다.
- SSE 연결 직후 누락 알림을 먼저 전송한 뒤, 기존처럼 실시간 알림 스트림을 유지하도록 변경했습니다.
- SSE 재연결 복구 흐름을 검증하는 단위 테스트를 추가했습니다.

## 🛠️ How - 어떻게 해결했나요?

- 클라이언트가 마지막으로 받은 SSE event id를 `Last-Event-ID` 헤더 또는 `lastEventId` 쿼리 파라미터로 전달하면, 서버가 해당 값 이후의 알림을 DB에서 조회합니다.
- 조회된 누락 알림은 기존 실시간 알림과 동일하게 `notification` 이벤트로 전송하며, `notificationId`를 SSE event id로 사용합니다.
- Redis Pub/Sub은 실시간 전달 트리거로 유지하고, 재시작/연결 끊김/메시지 유실 상황의 복구 기준은 DB의 `Notification` 데이터로 분리했습니다.
- `Last-Event-ID` 헤더를 사용하기 어려운 클라이언트도 고려해 `lastEventId` 쿼리 파라미터를 함께 지원했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 알림 구독 시 마지막 수신 이벤트 ID를 헤더 또는 쿼리 파라미터로 전달할 수 있도록 개선됨
  * 연결이 끊겼다가 다시 연결될 때 놓친 알림을 자동으로 수신하는 기능 추가됨

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/StartUpLight/STARLIGHT_BE/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->