### PR TITLE
[SRLT-159] 알림 Redis payload 축소

### DIFF
--- a/src/main/java/starlight/adapter/notification/persistence/NotificationJpa.java
+++ b/src/main/java/starlight/adapter/notification/persistence/NotificationJpa.java
@@ -31,4 +31,9 @@ public class NotificationJpa implements NotificationCommandPort, NotificationQue
     public List<Notification> findAllByMemberIdOrderByIdDesc(Long memberId) {
         return notificationRepository.findAllByMemberIdOrderByIdDesc(memberId);
     }
+
+    @Override
+    public List<Notification> findAllByMemberIdAndIdGreaterThanOrderByIdAsc(Long memberId, Long notificationId) {
+        return notificationRepository.findAllByMemberIdAndIdGreaterThanOrderByIdAsc(memberId, notificationId);
+    }
 }

--- a/src/main/java/starlight/adapter/notification/persistence/NotificationJpa.java
+++ b/src/main/java/starlight/adapter/notification/persistence/NotificationJpa.java
@@ -1,6 +1,7 @@
 package starlight.adapter.notification.persistence;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 import starlight.application.notification.required.NotificationCommandPort;
 import starlight.application.notification.required.NotificationQueryPort;
@@ -33,7 +34,15 @@ public class NotificationJpa implements NotificationCommandPort, NotificationQue
     }
 
     @Override
-    public List<Notification> findAllByMemberIdAndIdGreaterThanOrderByIdAsc(Long memberId, Long notificationId) {
-        return notificationRepository.findAllByMemberIdAndIdGreaterThanOrderByIdAsc(memberId, notificationId);
+    public List<Notification> findAllByMemberIdAndIdGreaterThanOrderByIdAsc(
+            Long memberId,
+            Long notificationId,
+            int limit
+    ) {
+        return notificationRepository.findAllByMemberIdAndIdGreaterThanOrderByIdAsc(
+                memberId,
+                notificationId,
+                PageRequest.of(0, limit)
+        );
     }
 }

--- a/src/main/java/starlight/adapter/notification/persistence/NotificationRepository.java
+++ b/src/main/java/starlight/adapter/notification/persistence/NotificationRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     List<Notification> findAllByMemberIdOrderByIdDesc(Long memberId);
+
+    List<Notification> findAllByMemberIdAndIdGreaterThanOrderByIdAsc(Long memberId, Long notificationId);
 }

--- a/src/main/java/starlight/adapter/notification/persistence/NotificationRepository.java
+++ b/src/main/java/starlight/adapter/notification/persistence/NotificationRepository.java
@@ -1,6 +1,9 @@
 package starlight.adapter.notification.persistence;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import starlight.domain.notification.entity.Notification;
 
 import java.util.List;
@@ -9,5 +12,16 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     List<Notification> findAllByMemberIdOrderByIdDesc(Long memberId);
 
-    List<Notification> findAllByMemberIdAndIdGreaterThanOrderByIdAsc(Long memberId, Long notificationId);
+    @Query("""
+            select notification
+            from Notification notification
+            where notification.memberId = :memberId
+              and notification.id > :notificationId
+            order by notification.id asc
+            """)
+    List<Notification> findAllByMemberIdAndIdGreaterThanOrderByIdAsc(
+            @Param("memberId") Long memberId,
+            @Param("notificationId") Long notificationId,
+            Pageable pageable
+    );
 }

--- a/src/main/java/starlight/adapter/notification/redis/RedisNotificationSubscriber.java
+++ b/src/main/java/starlight/adapter/notification/redis/RedisNotificationSubscriber.java
@@ -6,7 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.stereotype.Component;
-import starlight.application.notification.required.NotificationRealtimePort;
+import starlight.application.notification.provided.NotificationUseCase;
 import starlight.application.notification.required.dto.NotificationPublishMessage;
 
 import java.nio.charset.StandardCharsets;
@@ -17,7 +17,7 @@ import java.nio.charset.StandardCharsets;
 public class RedisNotificationSubscriber implements MessageListener {
 
     private final ObjectMapper objectMapper;
-    private final NotificationRealtimePort notificationRealtimePort;
+    private final NotificationUseCase notificationUseCase;
 
     @Override
     public void onMessage(Message message, byte[] pattern) {
@@ -28,7 +28,7 @@ public class RedisNotificationSubscriber implements MessageListener {
     void handlePayload(String payload) {
         try {
             NotificationPublishMessage publishMessage = objectMapper.readValue(payload, NotificationPublishMessage.class);
-            notificationRealtimePort.send(publishMessage);
+            notificationUseCase.sendRealtime(publishMessage);
         } catch (Exception exception) {
             log.warn("[NOTIFICATION] failed to consume redis payload={}", payload, exception);
         }

--- a/src/main/java/starlight/adapter/notification/sse/NotificationSseRegistry.java
+++ b/src/main/java/starlight/adapter/notification/sse/NotificationSseRegistry.java
@@ -7,7 +7,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import starlight.application.notification.required.NotificationRealtimePort;
-import starlight.application.notification.required.dto.NotificationPublishMessage;
+import starlight.application.notification.required.dto.NotificationRealtimeMessage;
 
 import java.io.IOException;
 import java.util.List;
@@ -25,7 +25,7 @@ public class NotificationSseRegistry implements NotificationRealtimePort {
     private final Map<Long, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
 
     @Override
-    public SseEmitter subscribe(Long memberId, List<NotificationPublishMessage> missedMessages) {
+    public SseEmitter subscribe(Long memberId, List<NotificationRealtimeMessage> missedMessages) {
         SseEmitter emitter = new SseEmitter(sseTimeoutMs);
         addEmitter(memberId, emitter);
 
@@ -50,7 +50,13 @@ public class NotificationSseRegistry implements NotificationRealtimePort {
     }
 
     @Override
-    public void send(NotificationPublishMessage message) {
+    public boolean hasSubscriber(Long memberId) {
+        List<SseEmitter> memberEmitters = emitters.get(memberId);
+        return memberEmitters != null && !memberEmitters.isEmpty();
+    }
+
+    @Override
+    public void send(NotificationRealtimeMessage message) {
         List<SseEmitter> memberEmitters = emitters.get(message.memberId());
         if (memberEmitters == null || memberEmitters.isEmpty()) {
             return;
@@ -100,9 +106,9 @@ public class NotificationSseRegistry implements NotificationRealtimePort {
     private void sendMissedMessages(
             SseEmitter emitter,
             Long memberId,
-            List<NotificationPublishMessage> missedMessages
+            List<NotificationRealtimeMessage> missedMessages
     ) throws IOException {
-        for (NotificationPublishMessage missedMessage : missedMessages) {
+        for (NotificationRealtimeMessage missedMessage : missedMessages) {
             if (!memberId.equals(missedMessage.memberId())) {
                 continue;
             }
@@ -111,7 +117,7 @@ public class NotificationSseRegistry implements NotificationRealtimePort {
         }
     }
 
-    private SseEmitter.SseEventBuilder createNotificationEvent(NotificationPublishMessage message) {
+    private SseEmitter.SseEventBuilder createNotificationEvent(NotificationRealtimeMessage message) {
         return SseEmitter.event()
                 .id(String.valueOf(message.notificationId()))
                 .name("notification")

--- a/src/main/java/starlight/adapter/notification/sse/NotificationSseRegistry.java
+++ b/src/main/java/starlight/adapter/notification/sse/NotificationSseRegistry.java
@@ -25,7 +25,7 @@ public class NotificationSseRegistry implements NotificationRealtimePort {
     private final Map<Long, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
 
     @Override
-    public SseEmitter subscribe(Long memberId) {
+    public SseEmitter subscribe(Long memberId, List<NotificationPublishMessage> missedMessages) {
         SseEmitter emitter = new SseEmitter(sseTimeoutMs);
         addEmitter(memberId, emitter);
 
@@ -40,6 +40,7 @@ public class NotificationSseRegistry implements NotificationRealtimePort {
                             .name("connected")
                             .data("ok", MediaType.TEXT_PLAIN)
             );
+            sendMissedMessages(emitter, memberId, missedMessages);
         } catch (IOException | IllegalStateException exception) {
             removeEmitter(memberId, emitter);
             emitter.completeWithError(exception);
@@ -59,10 +60,7 @@ public class NotificationSseRegistry implements NotificationRealtimePort {
             try {
                 safeSend(
                         emitter,
-                        SseEmitter.event()
-                                .id(String.valueOf(message.notificationId()))
-                                .name("notification")
-                                .data(message, MediaType.APPLICATION_JSON)
+                        createNotificationEvent(message)
                 );
             } catch (IOException | IllegalStateException exception) {
                 log.warn("[NOTIFICATION] SSE send failed notificationId={}, memberId={}",
@@ -97,6 +95,27 @@ public class NotificationSseRegistry implements NotificationRealtimePort {
                 }
             }
         }
+    }
+
+    private void sendMissedMessages(
+            SseEmitter emitter,
+            Long memberId,
+            List<NotificationPublishMessage> missedMessages
+    ) throws IOException {
+        for (NotificationPublishMessage missedMessage : missedMessages) {
+            if (!memberId.equals(missedMessage.memberId())) {
+                continue;
+            }
+
+            safeSend(emitter, createNotificationEvent(missedMessage));
+        }
+    }
+
+    private SseEmitter.SseEventBuilder createNotificationEvent(NotificationPublishMessage message) {
+        return SseEmitter.event()
+                .id(String.valueOf(message.notificationId()))
+                .name("notification")
+                .data(message, MediaType.APPLICATION_JSON);
     }
 
     private void addEmitter(Long memberId, SseEmitter emitter) {

--- a/src/main/java/starlight/adapter/notification/webapi/NotificationController.java
+++ b/src/main/java/starlight/adapter/notification/webapi/NotificationController.java
@@ -7,8 +7,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import starlight.adapter.notification.webapi.dto.request.NotificationTestRequest;
@@ -32,13 +34,16 @@ public class NotificationController implements NotificationApiDoc {
     @Override
     @GetMapping("/subscribe")
     public SseEmitter subscribe(
-            @AuthenticationPrincipal AuthenticatedMember authenticatedMember
+            @AuthenticationPrincipal AuthenticatedMember authenticatedMember,
+            @RequestHeader(value = "Last-Event-ID", required = false) Long lastEventIdHeader,
+            @RequestParam(value = "lastEventId", required = false) Long lastEventId
     ) {
         if (authenticatedMember == null) {
             throw new GlobalException(GlobalErrorType.UNAUTHORIZED);
         }
 
-        return notificationUseCase.subscribe(authenticatedMember.getMemberId());
+        Long resolvedLastEventId = lastEventId != null ? lastEventId : lastEventIdHeader;
+        return notificationUseCase.subscribe(authenticatedMember.getMemberId(), resolvedLastEventId);
     }
 
     @Override

--- a/src/main/java/starlight/adapter/notification/webapi/NotificationController.java
+++ b/src/main/java/starlight/adapter/notification/webapi/NotificationController.java
@@ -42,7 +42,7 @@ public class NotificationController implements NotificationApiDoc {
             throw new GlobalException(GlobalErrorType.UNAUTHORIZED);
         }
 
-        Long resolvedLastEventId = lastEventId != null ? lastEventId : lastEventIdHeader;
+        Long resolvedLastEventId = lastEventIdHeader != null ? lastEventIdHeader : lastEventId;
         return notificationUseCase.subscribe(authenticatedMember.getMemberId(), resolvedLastEventId);
     }
 

--- a/src/main/java/starlight/adapter/notification/webapi/swagger/NotificationApiDoc.java
+++ b/src/main/java/starlight/adapter/notification/webapi/swagger/NotificationApiDoc.java
@@ -1,6 +1,7 @@
 package starlight.adapter.notification.webapi.swagger;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -13,7 +14,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import starlight.adapter.notification.webapi.dto.request.NotificationTestRequest;
 import starlight.adapter.notification.webapi.dto.response.NotificationResponse;
@@ -29,7 +32,11 @@ public interface NotificationApiDoc {
     @Operation(summary = "알림 SSE를 구독합니다.")
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     SseEmitter subscribe(
-            @AuthenticationPrincipal AuthenticatedMember authenticatedMember
+            @AuthenticationPrincipal AuthenticatedMember authenticatedMember,
+            @Parameter(description = "SSE 재연결 시 브라우저가 전달하는 마지막 수신 이벤트 ID")
+            @RequestHeader(value = "Last-Event-ID", required = false) Long lastEventIdHeader,
+            @Parameter(description = "Last-Event-ID 헤더를 사용하기 어려운 클라이언트용 마지막 수신 이벤트 ID")
+            @RequestParam(value = "lastEventId", required = false) Long lastEventId
     );
 
     @Operation(summary = "내 알림 목록을 조회합니다.")

--- a/src/main/java/starlight/application/notification/NotificationService.java
+++ b/src/main/java/starlight/application/notification/NotificationService.java
@@ -1,6 +1,7 @@
 package starlight.application.notification;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +15,7 @@ import starlight.application.notification.required.NotificationOutboxCommandPort
 import starlight.application.notification.required.NotificationQueryPort;
 import starlight.application.notification.required.NotificationRealtimePort;
 import starlight.application.notification.required.dto.NotificationPublishMessage;
+import starlight.application.notification.required.dto.NotificationRealtimeMessage;
 import starlight.domain.notification.entity.Notification;
 import starlight.domain.notification.entity.NotificationOutbox;
 
@@ -29,6 +31,9 @@ public class NotificationService implements NotificationUseCase {
     private final NotificationQueryPort notificationQueryPort;
     private final NotificationRealtimePort notificationRealtimePort;
     private final ApplicationEventPublisher eventPublisher;
+
+    @Value("${notification.sse.recovery-limit:100}")
+    private int sseRecoveryLimit;
 
     @Override
     @Transactional
@@ -69,17 +74,32 @@ public class NotificationService implements NotificationUseCase {
     @Override
     @Transactional(readOnly = true)
     public SseEmitter subscribe(Long memberId, Long lastEventId) {
-        List<NotificationPublishMessage> missedMessages = findMissedMessages(memberId, lastEventId);
+        List<NotificationRealtimeMessage> missedMessages = findMissedMessages(memberId, lastEventId);
         return notificationRealtimePort.subscribe(memberId, missedMessages);
     }
 
-    private List<NotificationPublishMessage> findMissedMessages(Long memberId, Long lastEventId) {
+    @Override
+    @Transactional(readOnly = true)
+    public void sendRealtime(NotificationPublishMessage message) {
+        if (!notificationRealtimePort.hasSubscriber(message.memberId())) {
+            return;
+        }
+
+        Notification notification = notificationQueryPort.findByIdOrThrow(message.notificationId());
+        notificationRealtimePort.send(NotificationRealtimeMessage.from(notification));
+    }
+
+    private List<NotificationRealtimeMessage> findMissedMessages(Long memberId, Long lastEventId) {
         if (lastEventId == null || lastEventId <= 0) {
             return List.of();
         }
 
-        return notificationQueryPort.findAllByMemberIdAndIdGreaterThanOrderByIdAsc(memberId, lastEventId).stream()
-                .map(NotificationPublishMessage::from)
+        return notificationQueryPort.findAllByMemberIdAndIdGreaterThanOrderByIdAsc(
+                        memberId,
+                        lastEventId,
+                        sseRecoveryLimit
+                ).stream()
+                .map(NotificationRealtimeMessage::from)
                 .toList();
     }
 }

--- a/src/main/java/starlight/application/notification/NotificationService.java
+++ b/src/main/java/starlight/application/notification/NotificationService.java
@@ -13,6 +13,7 @@ import starlight.application.notification.required.NotificationCommandPort;
 import starlight.application.notification.required.NotificationOutboxCommandPort;
 import starlight.application.notification.required.NotificationQueryPort;
 import starlight.application.notification.required.NotificationRealtimePort;
+import starlight.application.notification.required.dto.NotificationPublishMessage;
 import starlight.domain.notification.entity.Notification;
 import starlight.domain.notification.entity.NotificationOutbox;
 
@@ -66,7 +67,19 @@ public class NotificationService implements NotificationUseCase {
     }
 
     @Override
-    public SseEmitter subscribe(Long memberId) {
-        return notificationRealtimePort.subscribe(memberId);
+    @Transactional(readOnly = true)
+    public SseEmitter subscribe(Long memberId, Long lastEventId) {
+        List<NotificationPublishMessage> missedMessages = findMissedMessages(memberId, lastEventId);
+        return notificationRealtimePort.subscribe(memberId, missedMessages);
+    }
+
+    private List<NotificationPublishMessage> findMissedMessages(Long memberId, Long lastEventId) {
+        if (lastEventId == null) {
+            return List.of();
+        }
+
+        return notificationQueryPort.findAllByMemberIdAndIdGreaterThanOrderByIdAsc(memberId, lastEventId).stream()
+                .map(NotificationPublishMessage::from)
+                .toList();
     }
 }

--- a/src/main/java/starlight/application/notification/NotificationService.java
+++ b/src/main/java/starlight/application/notification/NotificationService.java
@@ -74,7 +74,7 @@ public class NotificationService implements NotificationUseCase {
     }
 
     private List<NotificationPublishMessage> findMissedMessages(Long memberId, Long lastEventId) {
-        if (lastEventId == null) {
+        if (lastEventId == null || lastEventId <= 0) {
             return List.of();
         }
 

--- a/src/main/java/starlight/application/notification/provided/NotificationUseCase.java
+++ b/src/main/java/starlight/application/notification/provided/NotificationUseCase.java
@@ -3,6 +3,7 @@ package starlight.application.notification.provided;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import starlight.application.notification.provided.dto.input.NotificationSendInput;
 import starlight.application.notification.provided.dto.result.NotificationResult;
+import starlight.application.notification.required.dto.NotificationPublishMessage;
 
 import java.util.List;
 
@@ -15,4 +16,6 @@ public interface NotificationUseCase {
     void markAsRead(Long notificationId, Long memberId);
 
     SseEmitter subscribe(Long memberId, Long lastEventId);
+
+    void sendRealtime(NotificationPublishMessage message);
 }

--- a/src/main/java/starlight/application/notification/provided/NotificationUseCase.java
+++ b/src/main/java/starlight/application/notification/provided/NotificationUseCase.java
@@ -14,5 +14,5 @@ public interface NotificationUseCase {
 
     void markAsRead(Long notificationId, Long memberId);
 
-    SseEmitter subscribe(Long memberId);
+    SseEmitter subscribe(Long memberId, Long lastEventId);
 }

--- a/src/main/java/starlight/application/notification/required/NotificationQueryPort.java
+++ b/src/main/java/starlight/application/notification/required/NotificationQueryPort.java
@@ -9,4 +9,6 @@ public interface NotificationQueryPort {
     Notification findByIdOrThrow(Long notificationId);
 
     List<Notification> findAllByMemberIdOrderByIdDesc(Long memberId);
+
+    List<Notification> findAllByMemberIdAndIdGreaterThanOrderByIdAsc(Long memberId, Long notificationId);
 }

--- a/src/main/java/starlight/application/notification/required/NotificationQueryPort.java
+++ b/src/main/java/starlight/application/notification/required/NotificationQueryPort.java
@@ -10,5 +10,9 @@ public interface NotificationQueryPort {
 
     List<Notification> findAllByMemberIdOrderByIdDesc(Long memberId);
 
-    List<Notification> findAllByMemberIdAndIdGreaterThanOrderByIdAsc(Long memberId, Long notificationId);
+    List<Notification> findAllByMemberIdAndIdGreaterThanOrderByIdAsc(
+            Long memberId,
+            Long notificationId,
+            int limit
+    );
 }

--- a/src/main/java/starlight/application/notification/required/NotificationRealtimePort.java
+++ b/src/main/java/starlight/application/notification/required/NotificationRealtimePort.java
@@ -1,13 +1,15 @@
 package starlight.application.notification.required;
 
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-import starlight.application.notification.required.dto.NotificationPublishMessage;
+import starlight.application.notification.required.dto.NotificationRealtimeMessage;
 
 import java.util.List;
 
 public interface NotificationRealtimePort {
 
-    SseEmitter subscribe(Long memberId, List<NotificationPublishMessage> missedMessages);
+    SseEmitter subscribe(Long memberId, List<NotificationRealtimeMessage> missedMessages);
 
-    void send(NotificationPublishMessage message);
+    boolean hasSubscriber(Long memberId);
+
+    void send(NotificationRealtimeMessage message);
 }

--- a/src/main/java/starlight/application/notification/required/NotificationRealtimePort.java
+++ b/src/main/java/starlight/application/notification/required/NotificationRealtimePort.java
@@ -3,9 +3,11 @@ package starlight.application.notification.required;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import starlight.application.notification.required.dto.NotificationPublishMessage;
 
+import java.util.List;
+
 public interface NotificationRealtimePort {
 
-    SseEmitter subscribe(Long memberId);
+    SseEmitter subscribe(Long memberId, List<NotificationPublishMessage> missedMessages);
 
     void send(NotificationPublishMessage message);
 }

--- a/src/main/java/starlight/application/notification/required/dto/NotificationPublishMessage.java
+++ b/src/main/java/starlight/application/notification/required/dto/NotificationPublishMessage.java
@@ -1,29 +1,17 @@
 package starlight.application.notification.required.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import starlight.domain.notification.entity.Notification;
-
-import java.time.LocalDateTime;
 
 public record NotificationPublishMessage(
         Long memberId,
         Long notificationId,
-        String type,
-        String title,
-        String message,
-        Long referenceId,
-        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-        LocalDateTime createdAt
+        String type
 ) {
     public static NotificationPublishMessage from(Notification notification) {
         return new NotificationPublishMessage(
                 notification.getMemberId(),
                 notification.getId(),
-                notification.getType(),
-                notification.getTitle(),
-                notification.getMessage(),
-                notification.getReferenceId(),
-                notification.getCreatedAt()
+                notification.getType()
         );
     }
 }

--- a/src/main/java/starlight/application/notification/required/dto/NotificationRealtimeMessage.java
+++ b/src/main/java/starlight/application/notification/required/dto/NotificationRealtimeMessage.java
@@ -1,0 +1,29 @@
+package starlight.application.notification.required.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import starlight.domain.notification.entity.Notification;
+
+import java.time.LocalDateTime;
+
+public record NotificationRealtimeMessage(
+        Long memberId,
+        Long notificationId,
+        String type,
+        String title,
+        String message,
+        Long referenceId,
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime createdAt
+) {
+    public static NotificationRealtimeMessage from(Notification notification) {
+        return new NotificationRealtimeMessage(
+                notification.getMemberId(),
+                notification.getId(),
+                notification.getType(),
+                notification.getTitle(),
+                notification.getMessage(),
+                notification.getReferenceId(),
+                notification.getCreatedAt()
+        );
+    }
+}

--- a/src/test/java/starlight/adapter/notification/redis/RedisNotificationSubscriberTest.java
+++ b/src/test/java/starlight/adapter/notification/redis/RedisNotificationSubscriberTest.java
@@ -1,16 +1,13 @@
 package starlight.adapter.notification.redis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import starlight.application.notification.required.NotificationRealtimePort;
+import starlight.application.notification.provided.NotificationUseCase;
 import starlight.application.notification.required.dto.NotificationPublishMessage;
-
-import java.time.LocalDateTime;
 
 import static org.mockito.Mockito.*;
 
@@ -18,7 +15,7 @@ import static org.mockito.Mockito.*;
 class RedisNotificationSubscriberTest {
 
     @Mock
-    private NotificationRealtimePort notificationRealtimePort;
+    private NotificationUseCase notificationUseCase;
 
     private RedisNotificationSubscriber redisNotificationSubscriber;
     private ObjectMapper objectMapper;
@@ -26,8 +23,7 @@ class RedisNotificationSubscriberTest {
     @BeforeEach
     void setUp() {
         objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-        redisNotificationSubscriber = new RedisNotificationSubscriber(objectMapper, notificationRealtimePort);
+        redisNotificationSubscriber = new RedisNotificationSubscriber(objectMapper, notificationUseCase);
     }
 
     @Test
@@ -35,24 +31,20 @@ class RedisNotificationSubscriberTest {
         NotificationPublishMessage publishMessage = new NotificationPublishMessage(
                 1L,
                 2L,
-                "SYSTEM",
-                "title",
-                "message",
-                3L,
-                LocalDateTime.of(2026, 3, 27, 12, 0)
+                "SYSTEM"
         );
 
         String payload = objectMapper.writeValueAsString(publishMessage);
 
         redisNotificationSubscriber.handlePayload(payload);
 
-        verify(notificationRealtimePort).send(publishMessage);
+        verify(notificationUseCase).sendRealtime(publishMessage);
     }
 
     @Test
     void onMessage_잘못된메시지면_무시한다() {
         redisNotificationSubscriber.handlePayload("not-json");
 
-        verifyNoInteractions(notificationRealtimePort);
+        verifyNoInteractions(notificationUseCase);
     }
 }

--- a/src/test/java/starlight/adapter/notification/webapi/NotificationControllerTest.java
+++ b/src/test/java/starlight/adapter/notification/webapi/NotificationControllerTest.java
@@ -1,0 +1,62 @@
+package starlight.adapter.notification.webapi;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import starlight.application.notification.provided.NotificationUseCase;
+import starlight.shared.auth.AuthenticatedMember;
+import starlight.shared.apiPayload.exception.GlobalException;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class NotificationControllerTest {
+
+    private final NotificationUseCase notificationUseCase = mock(NotificationUseCase.class);
+    private final NotificationController notificationController = new NotificationController(notificationUseCase);
+
+    @Test
+    void subscribe_LastEventId헤더를_쿼리파라미터보다_우선한다() {
+        SseEmitter emitter = new SseEmitter();
+        AuthenticatedMember member = new TestAuthenticatedMember(1L, "tester");
+
+        when(notificationUseCase.subscribe(1L, 20L)).thenReturn(emitter);
+
+        SseEmitter result = notificationController.subscribe(member, 20L, 10L);
+
+        assertSame(emitter, result);
+        verify(notificationUseCase).subscribe(1L, 20L);
+    }
+
+    @Test
+    void subscribe_LastEventId헤더가_없으면_쿼리파라미터를_사용한다() {
+        SseEmitter emitter = new SseEmitter();
+        AuthenticatedMember member = new TestAuthenticatedMember(1L, "tester");
+
+        when(notificationUseCase.subscribe(1L, 10L)).thenReturn(emitter);
+
+        SseEmitter result = notificationController.subscribe(member, null, 10L);
+
+        assertSame(emitter, result);
+        verify(notificationUseCase).subscribe(1L, 10L);
+    }
+
+    @Test
+    void subscribe_인증정보가_없으면_예외가_발생한다() {
+        assertThrows(GlobalException.class, () -> notificationController.subscribe(null, null, null));
+    }
+
+    private record TestAuthenticatedMember(Long memberId, String memberName) implements AuthenticatedMember {
+        @Override
+        public Long getMemberId() {
+            return memberId;
+        }
+
+        @Override
+        public String getMemberName() {
+            return memberName;
+        }
+    }
+}

--- a/src/test/java/starlight/application/notification/NotificationOutboxPublishServiceUnitTest.java
+++ b/src/test/java/starlight/application/notification/NotificationOutboxPublishServiceUnitTest.java
@@ -24,6 +24,7 @@ import java.time.LocalDateTime;
 import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -87,7 +88,11 @@ class NotificationOutboxPublishServiceUnitTest {
 
         assertTrue(result);
         assertEquals(NotificationOutboxStatus.SENT, outbox.getStatus());
-        verify(notificationPublishPort).publish(any(NotificationPublishMessage.class));
+        var messageCaptor = forClass(NotificationPublishMessage.class);
+        verify(notificationPublishPort).publish(messageCaptor.capture());
+        assertEquals(1L, messageCaptor.getValue().memberId());
+        assertEquals(10L, messageCaptor.getValue().notificationId());
+        assertEquals("SYSTEM", messageCaptor.getValue().type());
     }
 
     @Test

--- a/src/test/java/starlight/application/notification/NotificationServiceUnitTest.java
+++ b/src/test/java/starlight/application/notification/NotificationServiceUnitTest.java
@@ -1,5 +1,6 @@
 package starlight.application.notification;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -15,6 +16,7 @@ import starlight.application.notification.required.NotificationCommandPort;
 import starlight.application.notification.required.NotificationOutboxCommandPort;
 import starlight.application.notification.required.NotificationQueryPort;
 import starlight.application.notification.required.NotificationRealtimePort;
+import starlight.application.notification.required.dto.NotificationPublishMessage;
 import starlight.domain.notification.entity.Notification;
 import starlight.domain.notification.entity.NotificationOutbox;
 import starlight.domain.notification.exception.NotificationException;
@@ -45,6 +47,11 @@ class NotificationServiceUnitTest {
 
     @InjectMocks
     private NotificationService notificationService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(notificationService, "sseRecoveryLimit", 100);
+    }
 
     @Test
     void notifyMember_저장후_이벤트를_발행한다() {
@@ -119,14 +126,14 @@ class NotificationServiceUnitTest {
         Notification notification = Notification.create(1L, "SYSTEM", "title", "message", null);
         ReflectionTestUtils.setField(notification, "id", 11L);
 
-        when(notificationQueryPort.findAllByMemberIdAndIdGreaterThanOrderByIdAsc(1L, 10L))
+        when(notificationQueryPort.findAllByMemberIdAndIdGreaterThanOrderByIdAsc(1L, 10L, 100))
                 .thenReturn(List.of(notification));
         when(notificationRealtimePort.subscribe(eq(1L), anyList())).thenReturn(emitter);
 
         SseEmitter result = notificationService.subscribe(1L, 10L);
 
         assertSame(emitter, result);
-        verify(notificationQueryPort).findAllByMemberIdAndIdGreaterThanOrderByIdAsc(1L, 10L);
+        verify(notificationQueryPort).findAllByMemberIdAndIdGreaterThanOrderByIdAsc(1L, 10L, 100);
         verify(notificationRealtimePort).subscribe(eq(1L), argThat(messages ->
                 messages.size() == 1 && messages.getFirst().notificationId().equals(11L)
         ));
@@ -141,6 +148,38 @@ class NotificationServiceUnitTest {
         SseEmitter result = notificationService.subscribe(1L, 0L);
 
         assertSame(emitter, result);
-        verify(notificationQueryPort, never()).findAllByMemberIdAndIdGreaterThanOrderByIdAsc(anyLong(), anyLong());
+        verify(notificationQueryPort, never())
+                .findAllByMemberIdAndIdGreaterThanOrderByIdAsc(anyLong(), anyLong(), anyInt());
+    }
+
+    @Test
+    void sendRealtime_구독자가_없으면_DB를_조회하지_않는다() {
+        NotificationPublishMessage message = new NotificationPublishMessage(1L, 10L, "SYSTEM");
+
+        when(notificationRealtimePort.hasSubscriber(1L)).thenReturn(false);
+
+        notificationService.sendRealtime(message);
+
+        verify(notificationQueryPort, never()).findByIdOrThrow(anyLong());
+        verify(notificationRealtimePort, never()).send(any());
+    }
+
+    @Test
+    void sendRealtime_구독자가_있으면_DB조회후_실시간전송한다() {
+        NotificationPublishMessage message = new NotificationPublishMessage(1L, 10L, "SYSTEM");
+        Notification notification = Notification.create(1L, "SYSTEM", "title", "message", null);
+        ReflectionTestUtils.setField(notification, "id", 10L);
+
+        when(notificationRealtimePort.hasSubscriber(1L)).thenReturn(true);
+        when(notificationQueryPort.findByIdOrThrow(10L)).thenReturn(notification);
+
+        notificationService.sendRealtime(message);
+
+        verify(notificationQueryPort).findByIdOrThrow(10L);
+        verify(notificationRealtimePort).send(argThat(realtimeMessage ->
+                realtimeMessage.notificationId().equals(10L)
+                        && realtimeMessage.title().equals("title")
+                        && realtimeMessage.message().equals("message")
+        ));
     }
 }

--- a/src/test/java/starlight/application/notification/NotificationServiceUnitTest.java
+++ b/src/test/java/starlight/application/notification/NotificationServiceUnitTest.java
@@ -131,4 +131,16 @@ class NotificationServiceUnitTest {
                 messages.size() == 1 && messages.getFirst().notificationId().equals(11L)
         ));
     }
+
+    @Test
+    void subscribe_lastEventId가_0이하면_누락알림을_조회하지_않는다() {
+        SseEmitter emitter = new SseEmitter();
+
+        when(notificationRealtimePort.subscribe(1L, List.of())).thenReturn(emitter);
+
+        SseEmitter result = notificationService.subscribe(1L, 0L);
+
+        assertSame(emitter, result);
+        verify(notificationQueryPort, never()).findAllByMemberIdAndIdGreaterThanOrderByIdAsc(anyLong(), anyLong());
+    }
 }

--- a/src/test/java/starlight/application/notification/NotificationServiceUnitTest.java
+++ b/src/test/java/starlight/application/notification/NotificationServiceUnitTest.java
@@ -106,10 +106,29 @@ class NotificationServiceUnitTest {
     void subscribe_실시간포트에_위임한다() {
         SseEmitter emitter = new SseEmitter();
 
-        when(notificationRealtimePort.subscribe(1L)).thenReturn(emitter);
+        when(notificationRealtimePort.subscribe(1L, List.of())).thenReturn(emitter);
 
-        SseEmitter result = notificationService.subscribe(1L);
+        SseEmitter result = notificationService.subscribe(1L, null);
 
         assertSame(emitter, result);
+    }
+
+    @Test
+    void subscribe_lastEventId가_있으면_누락알림을_조회해_전달한다() {
+        SseEmitter emitter = new SseEmitter();
+        Notification notification = Notification.create(1L, "SYSTEM", "title", "message", null);
+        ReflectionTestUtils.setField(notification, "id", 11L);
+
+        when(notificationQueryPort.findAllByMemberIdAndIdGreaterThanOrderByIdAsc(1L, 10L))
+                .thenReturn(List.of(notification));
+        when(notificationRealtimePort.subscribe(eq(1L), anyList())).thenReturn(emitter);
+
+        SseEmitter result = notificationService.subscribe(1L, 10L);
+
+        assertSame(emitter, result);
+        verify(notificationQueryPort).findAllByMemberIdAndIdGreaterThanOrderByIdAsc(1L, 10L);
+        verify(notificationRealtimePort).subscribe(eq(1L), argThat(messages ->
+                messages.size() == 1 && messages.getFirst().notificationId().equals(11L)
+        ));
     }
 }


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- 기존 Redis Pub/Sub 메시지가 알림 본문 전체를 포함하고 있어, Redis가 실시간 전달 신호와 알림 데이터 전달 역할을 함께 맡고 있었습니다.
- 서버 수가 늘어나는 구조에서는 Pub/Sub 메시지가 여러 WAS로 전파되므로, payload를 줄이고 알림 원본은 DB로 명확히 분리할 필요가 있었습니다.
- SSE 재연결 복구 시 `lastEventId` 이후 알림을 제한 없이 조회할 수 있어, 장시간 미접속 후 재연결 시 과도한 복구 전송이 발생할 수 있었습니다.

## ✅ What - 무엇이 변경됐나요?

- Redis Pub/Sub용 `NotificationPublishMessage` payload를 `memberId`, `notificationId`, `type`으로 축소했습니다.
- SSE 전송용 `NotificationRealtimeMessage`를 추가해 Redis 메시지와 클라이언트 전송 메시지의 역할을 분리했습니다.
- Redis 메시지 수신 시 현재 WAS에 해당 사용자의 SSE 구독자가 있는 경우에만 DB에서 알림 본문을 조회해 전송하도록 변경했습니다.
- SSE 재연결 복구 조회에 `notification.sse.recovery-limit` 설정을 추가하고 기본값을 100개로 제한했습니다.
- `Last-Event-ID` 헤더 우선순위, payload 축소, 구독자 유무에 따른 DB 조회 여부를 검증하는 테스트를 추가했습니다.

## 🛠️ How - 어떻게 해결했나요?

- Outbox publisher는 기존처럼 알림을 DB에서 조회하지만, Redis에는 알림 본문 전체가 아닌 `memberId`, `notificationId`, `type`만 publish합니다.
- Redis subscriber는 메시지를 직접 SSE adapter로 보내지 않고 `NotificationUseCase.sendRealtime(...)`로 전달합니다.
- `sendRealtime(...)`에서는 먼저 현재 서버에 해당 `memberId`의 SSE emitter가 있는지 확인하고, 없으면 DB 조회 없이 종료합니다.
- 구독자가 있는 경우에만 `notificationId`로 DB에서 알림을 조회한 뒤 `NotificationRealtimeMessage`로 변환해 SSE로 전송합니다.
- 재연결 복구는 `memberId + lastEventId` 이후 알림을 id 오름차순으로 조회하되, 설정값 기준 최대 개수까지만 전송하도록 제한했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**새로운 기능**
* 실시간 알림 구독 시 연결 재개 시 놓친 알림 자동 복구 기능 추가
* Last-Event-ID 헤더를 통한 마지막 수신 이벤트 추적 지원

**테스트**
* 실시간 알림 전송 및 구독 기능 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/StartUpLight/STARLIGHT_BE/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->